### PR TITLE
PR 1 / 3 - GPIO Simulation via Keyboard on Windows

### DIFF
--- a/JukeCore/Button.cs
+++ b/JukeCore/Button.cs
@@ -20,7 +20,7 @@ namespace JukeCore
         {
             try
             {
-                _console.WriteLine($"Opening GPIO {gpioNumber} ...");
+                _console.WriteLine($"Opening GPIO {gpioNumber} for {GetType().Name}...");
                 _gpioController.OpenPin(gpioNumber);
                 _console.WriteLine(
                     $"GPIO {gpioNumber} was opened! Initial value: {_gpioController.Read(gpioNumber).ToString()}");

--- a/JukeCore/ConsoleWrapper.cs
+++ b/JukeCore/ConsoleWrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using System.Threading;
 
 namespace JukeCore
 {
@@ -46,22 +47,26 @@ namespace JukeCore
             bool lineComplete = false;
             do
             {
-                var key = Console.ReadKey(true);
-
-                if (IsFunctionKey(key.Key))
+                if (Console.KeyAvailable)
                 {
-                    OnFunctionKeyPressed?.Invoke(this, key.Key);
-                    continue;
+                    var key = Console.ReadKey(true);
+
+                    if (IsFunctionKey(key.Key))
+                    {
+                        OnFunctionKeyPressed?.Invoke(this, key.Key);
+                        continue;
+                    }
+
+                    if (key.Key == ConsoleKey.Enter)
+                    {
+                        lineComplete = true;
+                    }
+
+                    Console.Write(key.KeyChar);
+                    readLine.Append(key.KeyChar);
                 }
 
-                if (key.Key == ConsoleKey.Enter)
-                {
-                    lineComplete = true;
-                }
-
-                Console.Write(key.KeyChar);
-                readLine.Append(key.KeyChar);
-
+                Thread.Sleep(100);
             } 
             while (!lineComplete);
 

--- a/JukeCore/ConsoleWrapper.cs
+++ b/JukeCore/ConsoleWrapper.cs
@@ -1,17 +1,71 @@
 ﻿using System;
+using System.Text;
 
 namespace JukeCore
 {
-    public class ConsoleWrapper : IConsole
+    public class ConsoleWrapper : IConsole, IFunctionKeyEvents
     {
+        public event EventHandler<ConsoleKey> OnFunctionKeyPressed;
+
         public void WriteLine(string value)
         {
             Console.WriteLine(value);
         }
 
+        private bool IsFunctionKey(ConsoleKey key)
+        {
+            return key == ConsoleKey.F1 ||
+                   key == ConsoleKey.F2 ||
+                   key == ConsoleKey.F3 ||
+                   key == ConsoleKey.F4 ||
+                   key == ConsoleKey.F5 ||
+                   key == ConsoleKey.F6 ||
+                   key == ConsoleKey.F7 ||
+                   key == ConsoleKey.F8 ||
+                   key == ConsoleKey.F9 ||
+                   key == ConsoleKey.F10 ||
+                   key == ConsoleKey.F11 ||
+                   key == ConsoleKey.F12 ||
+                   key == ConsoleKey.F13 ||
+                   key == ConsoleKey.F14 ||
+                   key == ConsoleKey.F15 ||
+                   key == ConsoleKey.F16 ||
+                   key == ConsoleKey.F17 ||
+                   key == ConsoleKey.F18 ||
+                   key == ConsoleKey.F19 ||
+                   key == ConsoleKey.F20 ||
+                   key == ConsoleKey.F21 ||
+                   key == ConsoleKey.F22 ||
+                   key == ConsoleKey.F23 ||
+                   key == ConsoleKey.F24;
+        }
+
         public string ReadLine()
         {
-            return Console.ReadLine();
+            var readLine = new StringBuilder();
+            bool lineComplete = false;
+            do
+            {
+                var key = Console.ReadKey(true);
+
+                if (IsFunctionKey(key.Key))
+                {
+                    OnFunctionKeyPressed?.Invoke(this, key.Key);
+                    continue;
+                }
+
+                if (key.Key == ConsoleKey.Enter)
+                {
+                    lineComplete = true;
+                }
+
+                Console.Write(key.KeyChar);
+                readLine.Append(key.KeyChar);
+
+            } 
+            while (!lineComplete);
+
+            return readLine.ToString().TrimEnd('\r', '\n');
         }
     }
 }

--- a/JukeCore/FunctionKeysGpioDriver.cs
+++ b/JukeCore/FunctionKeysGpioDriver.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Device.Gpio;
+using System.Linq;
+using System.Threading;
+
+namespace JukeCore
+{
+    /// <summary>
+    /// Simulates an gpio driver by pressing function keys on the keyboard
+    /// </summary>
+    public class FunctionKeysGpioDriver : GpioDriver
+    {
+        private readonly IFunctionKeyEvents _functionKeyEvents;
+        private readonly IConsole _console;
+        private readonly Dictionary<ConsoleKey, int> _openedPins = new Dictionary<ConsoleKey, int>();
+        private readonly Dictionary<int, PinValue> _pinValues = new Dictionary<int, PinValue>();
+        private readonly List<ConsoleKey> _assignedConsoleKeys = new List<ConsoleKey>();
+        private readonly PinValue _idlePinValue = PinValue.High;
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        public FunctionKeysGpioDriver(IFunctionKeyEvents functionKeyEvents, IConsole console)
+        {
+            _functionKeyEvents = functionKeyEvents;
+            _console = console;
+            _functionKeyEvents.OnFunctionKeyPressed += FunctionKeyPressed;
+        }
+
+        private ConsoleKey AssignNextFreeConsoleKey()
+        {
+            var nextKey = ConsoleKey.F1;
+
+            if (_assignedConsoleKeys.Count == PinCount)
+            {
+                throw new ArgumentException("The number of supported pins is reached. Close pins before being able to open new ones.");
+            }
+
+            if (_assignedConsoleKeys.Any())
+            {
+                var lastKey = _assignedConsoleKeys.Last();
+                nextKey = lastKey + 1;
+            }
+
+            _assignedConsoleKeys.Add(nextKey);
+
+
+            return nextKey;
+        }
+
+        private void FunctionKeyPressed(object sender, ConsoleKey e)
+        {
+            if (_openedPins.ContainsKey(e))
+            {
+                _pinValues[_openedPins[e]] = PinValue.Low;
+            }
+        }
+
+        protected override void AddCallbackForPinValueChangedEvent(int pinNumber, PinEventTypes eventTypes, PinChangeEventHandler callback)
+        {
+            throw new NotSupportedException("Only polling is supported on this implementation");
+        }
+
+        protected override void ClosePin(int pinNumber)
+        {
+            _pinValues.Remove(pinNumber);
+        }
+
+        protected override int ConvertPinNumberToLogicalNumberingScheme(int pinNumber)
+        {
+            return pinNumber;
+        }
+
+        protected override PinMode GetPinMode(int pinNumber)
+        {
+            return PinMode.Input;
+        }
+
+        protected override bool IsPinModeSupported(int pinNumber, PinMode mode)
+        {
+            return mode != PinMode.Output;
+        }
+
+        protected override void OpenPin(int pinNumber)
+        {
+            var nextKey = AssignNextFreeConsoleKey();
+            _openedPins.Add(nextKey, pinNumber);
+            _pinValues.Add(pinNumber, _idlePinValue);
+
+            _console.WriteLine($"Pin {pinNumber} is assigned to key {nextKey}");
+        }
+
+        protected override PinValue Read(int pinNumber)
+        {
+            var pinValue = _pinValues[pinNumber];
+            _pinValues[pinNumber] = _idlePinValue;
+            return pinValue;
+        }
+
+        protected override void RemoveCallbackForPinValueChangedEvent(int pinNumber, PinChangeEventHandler callback)
+        {
+            throw new NotSupportedException("Only polling is supported on this implementation");
+        }
+
+        protected override void SetPinMode(int pinNumber, PinMode mode)
+        {
+            if (mode == PinMode.Output)
+            {
+                throw new NotSupportedException("Only input pins are supported on this implementation");
+            }
+        }
+
+        protected override WaitForEventResult WaitForEvent(int pinNumber, PinEventTypes eventTypes, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException("Only polling is supported on this implementation");
+        }
+
+        protected override void Write(int pinNumber, PinValue value)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Allow to map 12 GPIOs (keyboard keys F1 to F12)
+        /// </summary>
+        protected override int PinCount => 12;
+
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _functionKeyEvents.OnFunctionKeyPressed -= FunctionKeyPressed;
+        }
+    }
+}

--- a/JukeCore/GpioDriverFactory.cs
+++ b/JukeCore/GpioDriverFactory.cs
@@ -1,0 +1,46 @@
+﻿using System.Device.Gpio;
+using System.Device.Gpio.Drivers;
+using System.Runtime.InteropServices;
+
+namespace JukeCore
+{
+    /// <summary>
+    /// Factory class to create a platform specific Gpio driver instance
+    /// </summary>
+    public class GpioDriverFactory
+    {
+        private readonly IConsole _console;
+        private readonly IFunctionKeyEvents _functionKeyEvents;
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        public GpioDriverFactory(IConsole console, IFunctionKeyEvents functionKeyEvents)
+        {
+            _console = console;
+            _functionKeyEvents = functionKeyEvents;
+        }
+
+
+        /// <summary>
+        /// Create the right GPIO driver for the detected platform
+        /// </summary>
+        public GpioDriver Create()
+        {
+            bool isWindows = RuntimeInformation
+                .IsOSPlatform(OSPlatform.Windows);
+
+            GpioDriver driver;
+            if (isWindows)
+            {
+                driver = new GpioSimulator(_functionKeyEvents, _console);
+            }
+            else
+            {
+                driver = new SysFsDriver();
+            }
+
+            return driver;
+        }
+    }
+}

--- a/JukeCore/GpioDriverFactory.cs
+++ b/JukeCore/GpioDriverFactory.cs
@@ -33,7 +33,7 @@ namespace JukeCore
             GpioDriver driver;
             if (isWindows)
             {
-                driver = new GpioSimulator(_functionKeyEvents, _console);
+                driver = new FunctionKeysGpioDriver(_functionKeyEvents, _console);
             }
             else
             {

--- a/JukeCore/IFunctionKeyEvents.cs
+++ b/JukeCore/IFunctionKeyEvents.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace JukeCore
+{
+    /// <summary>
+    /// Interface for allowing to register for events when function keys are pressed in console
+    /// </summary>
+    public interface IFunctionKeyEvents
+    {
+        event EventHandler<ConsoleKey> OnFunctionKeyPressed;
+    }
+}

--- a/JukeCore/JukeCore.csproj
+++ b/JukeCore/JukeCore.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="LibVLCSharp" Version="3.4.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="System.Device.Gpio" Version="1.0.0" />
     <PackageReference Include="System.IO.Abstractions" Version="12.0.2" />
     <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.11" />

--- a/JukeCore/Program.cs
+++ b/JukeCore/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Device.Gpio;
-using System.Device.Gpio.Drivers;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Threading.Tasks;
@@ -38,7 +37,8 @@ namespace JukeCore
                 var processor = new IdProcessor(commandFactory, _console, _playlist, _mediaPlayer);
                 var mainLoop = new MainLoop(_console, processor);
 
-                var driver = new SysFsDriver();
+                var gpioDriverFactory = new GpioDriverFactory(_console, _console);
+                var driver = gpioDriverFactory.Create();
                 var controller = new GpioController(PinNumberingScheme.Logical, driver);
                 var volDownButton = new VolumeDownButton(controller, _mediaPlayer, _console);
                 var volUpButton = new VolumeUpButton(controller, _mediaPlayer, _console);

--- a/JukeCore/VolumeUpButton.cs
+++ b/JukeCore/VolumeUpButton.cs
@@ -18,7 +18,7 @@ namespace JukeCore
 
         private void OnPressed(object sender, EventArgs e)
         {
-            _console.WriteLine("Volume down button was pressed!");
+            _console.WriteLine("Volume up button was pressed!");
             _mediaPlayer.Volume += 5;
         }
     }


### PR DESCRIPTION
This PR adds a GpioDriver implementation that mimics part of a fully fletched Gpio (input only, interrupt only) on windows by 
utilizing the keyboard. Up to 12 GPIOs can be used which are mapped to F1 to F12 (first opened pin gets F1, second F2 and so on - also indicated in console printouts).

 It also switches button detection from polling to interrupts (can be deactivated via compiler define "USE_GPIO_POLLING" for now because i don't have the actual hardware.

Button debounce times was reduced from 400ms to 50ms as well (might need to be changed to fit the button hardware).