### PR TITLE
PR 3/3 Mqtt - support

### DIFF
--- a/JukeCore/Button.cs
+++ b/JukeCore/Button.cs
@@ -17,6 +17,7 @@ namespace JukeCore
             _console = console;
         }
 
+        protected abstract void SetButtonStateInDataModel(EButtonState buttonState);
 
 #if USE_GPIO_POLLING
         public await Task Activate(int gpioNumber)
@@ -63,10 +64,15 @@ namespace JukeCore
         {
             if (args.ChangeType == PinEventTypes.Falling)
             {
+                SetButtonStateInDataModel(EButtonState.Pressed);
                 Pressed?.Invoke(this, EventArgs.Empty);
                 Thread.Sleep(50);
             }
 
+            if (args.ChangeType == PinEventTypes.Rising)
+            {
+                SetButtonStateInDataModel(EButtonState.Released);
+            }
         }
     }
 }

--- a/JukeCore/CommandLineArguments.cs
+++ b/JukeCore/CommandLineArguments.cs
@@ -1,0 +1,65 @@
+﻿using PowerArgs;
+
+namespace JukeCore
+{
+    /// <summary>
+    /// power args ...
+    /// </summary>
+    public class CommandLineArguments
+    {
+
+        /// <summary>
+        /// Show usage / argument help
+        /// </summary>
+        [HelpHook]
+        [ArgShortcut("?")]
+        public bool Help { get; set; }
+
+        /// <summary>
+        /// The path for the media files to be played back / handled by this juke core instance
+        /// </summary>
+        [ArgDescription("Absolute path to the media files")]
+        [ArgRequired(PromptIfMissing = false)]
+        [ArgShortcut("m")]
+        public string JukeCoreMediaPath { get; set; }
+
+        /// <summary>
+        /// Ip address of mqt broker. If not set
+        /// </summary>
+        [ArgDescription("If set - mqtt support is enabled with the given ip address for the mqtt broker")]
+        [ArgShortcut("h")]
+        public string MqttBrokerIp { get; set; }
+
+        /// <summary>
+        /// Mqtt port to be used to connect to the mqtt broker
+        /// </summary>
+        [ArgDescription("Optional mqtt broker tcp port")]
+        [ArgRange(1, 65535)]
+        [ArgDefaultValue(1883)]
+        [ArgShortcut("d")]
+        public int MqttPort { get; set; }
+
+        /// <summary>
+        /// User name for mqtt broker
+        /// </summary>
+        [ArgDescription("Optional mqtt user name")]
+        [ArgShortcut("u")]
+        public string MqttUsername { get; set; }
+
+        /// <summary>
+        /// Password for mqtt broker
+        /// </summary>
+        [ArgDescription("Mqtt password")]
+        [ArgRequired(If = "MqttUsername")]
+        [ArgShortcut("p")]
+        public string MqttPassword { get; set; }
+
+        /// <summary>
+        /// Mqtt prefix to be used
+        /// </summary>
+        [ArgDescription("Mqtt prefix to be used")]
+        [ArgRequired(If = "MqttBrokerIp")]
+        [ArgShortcut("x")]
+        public string MqttPrefix { get; set; }
+    }
+}

--- a/JukeCore/CommandTopicHandler.cs
+++ b/JukeCore/CommandTopicHandler.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+
+namespace JukeCore
+{
+    /// <summary>
+    /// Topic handler for handling next/prev/pause of playback
+    /// </summary>
+    public class CommandTopicHandler : ITopicHandler
+    {
+        private readonly IMediaPlayer _mediaPlayer;
+        private readonly IPlaylist _playlist;
+        private readonly string _mqttPrefix;
+
+        /// <inheritdoc />
+        public string Topic => $"jukeCore/{_mqttPrefix}/command";
+
+        public string Usage => $"Topic: {Topic} Payload: <NextTrack|PreviousTrack|PlayPause>";
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        public CommandTopicHandler(IMediaPlayer mediaPlayer, IPlaylist playlist, string mqttPrefix)
+        {
+            _mediaPlayer = mediaPlayer;
+            _playlist = playlist;
+            _mqttPrefix = mqttPrefix;
+        }
+
+        /// <inheritdoc />
+        public void HandlePayload(string payload)
+        {
+            switch (payload)
+            {
+                case "PlayPause":
+                    _mediaPlayer.Pause();
+                    break;
+                case "NextTrack":
+                    var nextMedia = _playlist.Next();
+
+                    ThreadPool.QueueUserWorkItem(_ => _mediaPlayer.Play(nextMedia));
+                    break;
+                case "PreviousTrack":
+                    var previousMedia = _playlist.Previous();
+
+                    ThreadPool.QueueUserWorkItem(_ => _mediaPlayer.Play(previousMedia));
+                    break;
+            }
+        }
+    }
+}

--- a/JukeCore/EButtonState.cs
+++ b/JukeCore/EButtonState.cs
@@ -1,0 +1,11 @@
+﻿namespace JukeCore
+{
+    /// <summary>
+    /// Possible states of a button
+    /// </summary>
+    public enum EButtonState
+    {
+        Released,
+        Pressed
+    }
+}

--- a/JukeCore/EPlaybackState.cs
+++ b/JukeCore/EPlaybackState.cs
@@ -1,0 +1,12 @@
+﻿namespace JukeCore
+{
+    /// <summary>
+    /// possible playback states
+    /// </summary>
+    public enum EPlaybackState
+    {
+        Playing,
+        Paused,
+        Stopped
+    }
+}

--- a/JukeCore/IMqttService.cs
+++ b/JukeCore/IMqttService.cs
@@ -1,0 +1,9 @@
+﻿namespace JukeCore
+{
+    /// <summary>
+    /// Interface for accessing looping mqtt service
+    /// </summary>
+    public interface IMqttService
+    {
+    }
+}

--- a/JukeCore/ITopicHandler.cs
+++ b/JukeCore/ITopicHandler.cs
@@ -1,0 +1,23 @@
+﻿namespace JukeCore
+{
+    /// <summary>
+    /// Interface for handling a topic payload
+    /// </summary>
+    public interface ITopicHandler
+    {
+        /// <summary>
+        /// Topic this handler handles
+        /// </summary>
+        string Topic { get; }
+
+        /// <summary>
+        /// Hint ready to display for the user (supported topic and payloads)
+        /// </summary>
+        string Usage { get; }
+
+        /// <summary>
+        /// Method that is called when the corresponding topic receives a message.
+        /// </summary>
+        void HandlePayload(string payload);
+    }
+}

--- a/JukeCore/JukeCore.csproj
+++ b/JukeCore/JukeCore.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="LibVLCSharp" Version="3.4.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
+    <PackageReference Include="PowerArgs" Version="3.6.0" />
     <PackageReference Include="System.Device.Gpio" Version="1.0.0" />
     <PackageReference Include="System.IO.Abstractions" Version="12.0.2" />
     <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.11" />

--- a/JukeCore/JukeCore.csproj
+++ b/JukeCore/JukeCore.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibVLCSharp" Version="3.4.5" />
+    <PackageReference Include="MQTTnet" Version="3.0.12" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="PowerArgs" Version="3.6.0" />

--- a/JukeCore/JukeCoreDataModel.cs
+++ b/JukeCore/JukeCoreDataModel.cs
@@ -1,0 +1,220 @@
+﻿using System;
+
+namespace JukeCore
+{
+    public class ChangedProperty
+    {
+        public string PropertyName { get; }
+
+        public string PropertyValue { get; }
+
+        public ChangedProperty(string propertyName, string propertyValue)
+        {
+            PropertyName = propertyName;
+            PropertyValue = propertyValue;
+        }
+    }
+
+    /// <summary>
+    /// Data model of the juke core state
+    /// </summary>
+    public class JukeCoreDataModel
+    {
+        private EPlaybackState _playbackState = EPlaybackState.Stopped;
+
+        /// <summary>
+        /// current playback state
+        /// </summary>
+        public EPlaybackState PlaybackState
+        {
+            get => _playbackState;
+            set
+            {
+                if (_playbackState != value)
+                {
+                    
+                    _playbackState = value;
+                    OnPropertyChange(new ChangedProperty(nameof(PlaybackState), value.ToString()));
+                }
+            }
+        }
+
+        private long _mediaDurationMs;
+
+        /// <summary>
+        /// duration of current played track in ms
+        /// </summary>
+        public long MediaDurationMs
+        {
+            get => _mediaDurationMs;
+            set
+            {
+                if (_mediaDurationMs != value)
+                {
+
+                    _mediaDurationMs = value;
+                    OnPropertyChange(new ChangedProperty(nameof(MediaDurationMs), value.ToString()));
+                }
+            }
+        }
+
+        private long _mediaPositionMs;
+
+        /// <summary>
+        /// position in current played track in ms
+        /// </summary>
+        public long MediaPositionMs
+        {
+            get => _mediaPositionMs;
+            set
+            {
+                if (_mediaPositionMs != value)
+                {
+
+                    _mediaPositionMs = value;
+                    OnPropertyChange(new ChangedProperty(nameof(MediaPositionMs), value.ToString()));
+                }
+            }
+        }
+
+        private byte _volumePercent;
+
+        /// <summary>
+        /// playback volume in percent
+        /// </summary>
+        public byte VolumePercent
+        {
+            get => _volumePercent;
+            set
+            {
+                if (_volumePercent != value)
+                {
+
+                    _volumePercent = value;
+                    OnPropertyChange(new ChangedProperty(nameof(VolumePercent), value.ToString()));
+                }
+            }
+        }
+
+        private string _mediaFilename;
+
+        /// <summary>
+        /// filename of current played track in ms
+        /// </summary>
+        public string MediaFilename
+        {
+            get => _mediaFilename;
+            set
+            {
+                if (_mediaFilename != value)
+                {
+
+                    _mediaFilename = value;
+                    OnPropertyChange(new ChangedProperty(nameof(MediaFilename), value));
+                }
+            }
+        }
+
+        private EButtonState _volumeDownButtonState;
+
+        /// <summary>
+        /// State of the volume down button
+        /// </summary>
+        public EButtonState VolumeDownButtonState
+        {
+            get => _volumeDownButtonState;
+            set
+            {
+                if (_volumeDownButtonState != value)
+                {
+
+                    _volumeDownButtonState = value;
+                    OnPropertyChange(new ChangedProperty(nameof(VolumeDownButtonState), value.ToString()));
+                }
+            }
+        }
+
+        private EButtonState _volumeUpButtonState;
+
+        /// <summary>
+        /// State of the volume up button
+        /// </summary>
+        public EButtonState VolumeUpButtonState
+        {
+            get => _volumeUpButtonState;
+            set
+            {
+                if (_volumeUpButtonState != value)
+                {
+
+                    _volumeUpButtonState = value;
+                    OnPropertyChange(new ChangedProperty(nameof(VolumeUpButtonState), value.ToString()));
+                }
+            }
+        }
+
+        private EButtonState _previousButtonState;
+
+        /// <summary>
+        /// State of the previous button
+        /// </summary>
+        public EButtonState PreviousButtonState
+        {
+            get => _previousButtonState;
+            set
+            {
+                if (_previousButtonState != value)
+                {
+
+                    _previousButtonState = value;
+                    OnPropertyChange(new ChangedProperty(nameof(PreviousButtonState), value.ToString()));
+                }
+            }
+        }
+
+        private EButtonState _nextButtonState;
+
+        /// <summary>
+        /// State of the next button
+        /// </summary>
+        public EButtonState NextButtonState
+        {
+            get => _nextButtonState;
+            set
+            {
+                if (_nextButtonState != value)
+                {
+
+                    _nextButtonState = value;
+                    OnPropertyChange(new ChangedProperty(nameof(NextButtonState), value.ToString()));
+                }
+            }
+        }
+
+        private EButtonState _playPauseButtonState;
+
+        /// <summary>
+        /// State of the play/pause button
+        /// </summary>
+        public EButtonState PlayPauseButtonState
+        {
+            get => _playPauseButtonState;
+            set
+            {
+                if (_playPauseButtonState != value)
+                {
+
+                    _playPauseButtonState = value;
+                    OnPropertyChange(new ChangedProperty(nameof(PlayPauseButtonState), value.ToString()));
+                }
+            }
+        }
+
+        public event EventHandler<ChangedProperty> OnPropertyChanged;
+
+        private void OnPropertyChange(ChangedProperty changedProperty)
+        {
+            OnPropertyChanged?.Invoke(this, changedProperty);
+        }
+    }
+}

--- a/JukeCore/MqttService.cs
+++ b/JukeCore/MqttService.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Client.Options;
+using Nito.AsyncEx;
+
+namespace JukeCore
+{
+    /// <summary>
+    /// This service publishes changes to the mqtt datamodel to an mqtt broker and receives commands from the latter.
+    /// </summary>
+    public class MqttService : IMqttService, IDisposable
+    {
+        private readonly IMqttClient _mqttClient;
+        private readonly IMqttClientOptions _mqttOptions;
+        private readonly IConsole _console;
+        private readonly JukeCoreDataModel _dataModel;
+        private readonly int _mqttTimeoutMs;
+        private readonly string _mqttPrefix;
+
+        private readonly Dictionary<string, string> _topicsToPublish;
+        private readonly List<ITopicHandler> _topicHandlers;
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        public MqttService(IMqttClient mqttClient,
+            IMqttClientOptions mqttOptions,
+            IConsole console,
+            List<ITopicHandler> topicHandlers,
+            Dictionary<string, string> topicsToPublish,
+            JukeCoreDataModel dataModel,
+            int mqttTimeoutMs,
+            string mqttPrefix)
+        {
+            _mqttClient = mqttClient;
+            _mqttOptions = mqttOptions;
+            _console = console;
+            _dataModel = dataModel;
+            _mqttTimeoutMs = mqttTimeoutMs;
+            _mqttPrefix = mqttPrefix;
+            _topicHandlers = topicHandlers;
+            _topicsToPublish = topicsToPublish;
+            SubscribeToDataModelEvents();
+            SubscribeToMqttEvents();
+        }
+
+        private void SubscribeToMqttEvents()
+        {
+            _mqttClient.UseApplicationMessageReceivedHandler(OnMqttMessageReceived);
+        }
+
+        private Task OnMqttMessageReceived(MqttApplicationMessageReceivedEventArgs arg)
+        {
+            string topic = arg.ApplicationMessage.Topic;
+            string payload = Encoding.UTF8.GetString(arg.ApplicationMessage.Payload);
+            var handler = _topicHandlers.Single(x => x.Topic.Equals(topic));
+
+            try
+            {
+                handler.HandlePayload(payload);
+ }
+            catch (Exception e)
+            {
+                _console.WriteLine(e.Message);
+            }
+
+            return Task.CompletedTask;
+        }
+        private void PrintTopicsToPublish()
+        {
+            foreach (var topicToPublish in _topicsToPublish)
+            {
+                _console.WriteLine($"Will publish dataModel.{topicToPublish.Value} to {topicToPublish.Key}");
+            }
+        }
+
+        private void SubscribeToDataModelEvents()
+        {
+            _dataModel.OnPropertyChanged += DataModelOnPropertyChanged;
+        }
+
+        private void DataModelOnPropertyChanged(object sender, ChangedProperty e)
+        {
+            try
+            {
+                var cts = new CancellationTokenSource();
+                cts.CancelAfter(_mqttTimeoutMs);
+                AsyncContext.Run(async () =>
+                {
+                    var topicEntry = _topicsToPublish.Single(x => x.Value.Equals(e.PropertyName));
+                    await PublishMessage(topicEntry.Key, e.PropertyValue, cts.Token);
+                });
+            }
+            catch
+            {
+                // nothing
+            }
+            
+        }
+
+        private async Task PublishMessage(string topic, string payload, CancellationToken token)
+        {
+            await EnsureConnected(token);
+
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic(topic)
+                .WithPayload(payload)
+                .WithExactlyOnceQoS()
+                .WithRetainFlag()
+                .Build();
+           await  _mqttClient.PublishAsync(message);
+        }
+
+        private async Task SubscribeMqttTopics()
+        {
+            foreach (var topicHandler in _topicHandlers)
+            {
+                var subscribeOptions =
+                    new MqttTopicFilterBuilder().WithTopic(topicHandler.Topic).Build();
+                await _mqttClient.SubscribeAsync(subscribeOptions);
+                _console.WriteLine($"Registered handler for {topicHandler.Usage}");
+            }
+        }
+
+        private async Task EnsureConnected(CancellationToken token)
+        {
+            bool connected = _mqttClient.IsConnected;
+            if (!connected)
+            {
+                await _mqttClient.ConnectAsync(_mqttOptions, token);
+                await SubscribeMqttTopics();
+                PrintTopicsToPublish();
+            }
+        }
+
+       public void Dispose()
+        {
+            _mqttClient?.Dispose();
+            _dataModel.OnPropertyChanged -= DataModelOnPropertyChanged;
+        }
+    }
+}

--- a/JukeCore/NextButton.cs
+++ b/JukeCore/NextButton.cs
@@ -9,14 +9,16 @@ namespace JukeCore
         private readonly IMediaPlayer _mediaPlayer;
         private readonly IPlaylist _playlist;
         private readonly IConsole _console;
+        private readonly JukeCoreDataModel _dataModel;
 
         public NextButton(GpioController gpioController, IMediaPlayer mediaPlayer, IPlaylist playlist,
-            IConsole console) : base(
+            IConsole console, JukeCoreDataModel dataModel) : base(
             gpioController, console)
         {
             _mediaPlayer = mediaPlayer;
             _playlist = playlist;
             _console = console;
+            _dataModel = dataModel;
             Pressed += OnPressed;
         }
 
@@ -33,6 +35,11 @@ namespace JukeCore
             {
                 _console.WriteLine(exception.Message);
             }
+        }
+
+        protected override void SetButtonStateInDataModel(EButtonState buttonState)
+        {
+            _dataModel.NextButtonState = buttonState;
         }
     }
 }

--- a/JukeCore/PlayIdTopicHandler.cs
+++ b/JukeCore/PlayIdTopicHandler.cs
@@ -1,0 +1,35 @@
+﻿namespace JukeCore
+{
+    /// <summary>
+    /// Topic handler for receiving play ids
+    /// </summary>p
+    public class PlayIdTopicHandler : ITopicHandler
+    {
+        private readonly IIdProcessor _idProcessor;
+        private readonly string _mqttPrefix;
+        private readonly string _jukeCoreMediaPath;
+
+        /// <inheritdoc />
+        public string Topic => $"jukeCore/{_mqttPrefix}/playId";
+
+        public string Usage => $"Topic: {Topic} Payload: <rfid id>";
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        public PlayIdTopicHandler(IIdProcessor idProcessor,
+            string mqttPrefix,
+            string jukeCoreMediaPath)
+        {
+            _idProcessor = idProcessor;
+            _mqttPrefix = mqttPrefix;
+            _jukeCoreMediaPath = jukeCoreMediaPath;
+        }
+
+        /// <inheritdoc />
+        public void HandlePayload(string payload)
+        {
+            _idProcessor.Process(payload, _jukeCoreMediaPath);
+        }
+    }
+}

--- a/JukeCore/PlayPauseButton.cs
+++ b/JukeCore/PlayPauseButton.cs
@@ -7,12 +7,14 @@ namespace JukeCore
     {
         private readonly IMediaPlayer _mediaPlayer;
         private readonly IConsole _console;
+        private readonly JukeCoreDataModel _dataModel;
 
-        public PlayPauseButton(GpioController gpioController, IMediaPlayer mediaPlayer, IConsole console) : base(
+        public PlayPauseButton(GpioController gpioController, IMediaPlayer mediaPlayer, IConsole console, JukeCoreDataModel dataModel) : base(
             gpioController, console)
         {
             _mediaPlayer = mediaPlayer;
             _console = console;
+            _dataModel = dataModel;
             Pressed += OnPressed;
         }
 
@@ -27,6 +29,11 @@ namespace JukeCore
             {
                 _console.WriteLine(exception.Message);
             }
+        }
+
+        protected override void SetButtonStateInDataModel(EButtonState buttonState)
+        {
+            _dataModel.PlayPauseButtonState = buttonState;
         }
     }
 }

--- a/JukeCore/PreviousButton.cs
+++ b/JukeCore/PreviousButton.cs
@@ -9,14 +9,16 @@ namespace JukeCore
         private readonly IMediaPlayer _mediaPlayer;
         private readonly IPlaylist _playlist;
         private readonly IConsole _console;
+        private readonly JukeCoreDataModel _dataModel;
 
         public PreviousButton(GpioController gpioController, IMediaPlayer mediaPlayer, IPlaylist playlist,
-            IConsole console) : base(
+            IConsole console, JukeCoreDataModel dataModel) : base(
             gpioController, console)
         {
             _mediaPlayer = mediaPlayer;
             _playlist = playlist;
             _console = console;
+            _dataModel = dataModel;
             Pressed += OnPressed;
         }
 
@@ -33,6 +35,11 @@ namespace JukeCore
             {
                 _console.WriteLine(exception.Message);
             }
+        }
+
+        protected override void SetButtonStateInDataModel(EButtonState buttonState)
+        {
+            _dataModel.PreviousButtonState = buttonState;
         }
     }
 }

--- a/JukeCore/Program.cs
+++ b/JukeCore/Program.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Threading.Tasks;
 using LibVLCSharp.Shared;
+using PowerArgs;
 
 namespace JukeCore
 {
@@ -15,12 +16,25 @@ namespace JukeCore
 
         public static async Task Main(string[] args)
         {
+            CommandLineArguments arguments;
             try
             {
+               arguments = Args.Parse<CommandLineArguments>(args);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                Console.WriteLine(ArgUsage.GenerateUsageFromTemplate<CommandLineArguments>());
+                return;
+            }
+
+            try
+            {
+                
                 _console = new ConsoleWrapper();
                 _console.WriteLine("JukeCore started!");
 
-                string jukeCoreMediaPath = args.First();
+                string jukeCoreMediaPath = arguments.JukeCoreMediaPath;
                 _console.WriteLine($"Path to media folder is: '{jukeCoreMediaPath}'.");
 
                 _console.WriteLine("Initialzing LibVLC ... ");

--- a/JukeCore/Program.cs
+++ b/JukeCore/Program.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Device.Gpio;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Threading.Tasks;
 using LibVLCSharp.Shared;
+using MQTTnet;
+using MQTTnet.Client.Options;
 using PowerArgs;
 
 namespace JukeCore
@@ -30,6 +32,7 @@ namespace JukeCore
 
             try
             {
+                var dataModel = new JukeCoreDataModel();
                 
                 _console = new ConsoleWrapper();
                 _console.WriteLine("JukeCore started!");
@@ -44,21 +47,24 @@ namespace JukeCore
                 var fileSystem = new FileSystem();
                 using var libVlc = new LibVLC();
                 _playlist = new Playlist(_console);
-                _mediaPlayer = new MediaPlayerWrapper(new MediaPlayer(libVlc), _console, _playlist);
+                _mediaPlayer = new MediaPlayerWrapper(new MediaPlayer(libVlc), _console, _playlist, dataModel);
+      
                 var commandFactory =
                     new MediaFactory(fileSystem.Directory,
                         fileSystem.Path, _console, libVlc);
                 var processor = new IdProcessor(commandFactory, _console, _playlist, _mediaPlayer);
                 var mainLoop = new MainLoop(_console, processor);
 
+                CreateMqttService(processor, arguments, dataModel);
+
                 var gpioDriverFactory = new GpioDriverFactory(_console, _console);
                 var driver = gpioDriverFactory.Create();
                 var controller = new GpioController(PinNumberingScheme.Logical, driver);
-                var volDownButton = new VolumeDownButton(controller, _mediaPlayer, _console);
-                var volUpButton = new VolumeUpButton(controller, _mediaPlayer, _console);
-                var previousButton = new PreviousButton(controller, _mediaPlayer, _playlist, _console);
-                var nextButton = new NextButton(controller, _mediaPlayer, _playlist, _console);
-                var playPlauseButton = new PlayPauseButton(controller, _mediaPlayer, _console);
+                var volDownButton = new VolumeDownButton(controller, _mediaPlayer, _console, dataModel);
+                var volUpButton = new VolumeUpButton(controller, _mediaPlayer, _console, dataModel);
+                var previousButton = new PreviousButton(controller, _mediaPlayer, _playlist, _console, dataModel);
+                var nextButton = new NextButton(controller, _mediaPlayer, _playlist, _console, dataModel);
+                var playPlauseButton = new PlayPauseButton(controller, _mediaPlayer, _console, dataModel);
 
 #pragma warning disable 4014
                 volDownButton.Activate(4);
@@ -74,6 +80,63 @@ namespace JukeCore
             {
                 _console.WriteLine(e.Message);
             }
+        }
+
+        private static void CreateMqttService(IdProcessor processor,
+            CommandLineArguments arguments, JukeCoreDataModel dataModel)
+        {
+
+            if (string.IsNullOrWhiteSpace(arguments.MqttPrefix))
+            {
+                _console.WriteLine("No mqtt ip was given. Mqtt service disabled.");
+                return;
+            }
+
+            _console.WriteLine($"Starting mqtt service with prefix {arguments.MqttPrefix}");
+
+            var mqttFactory = new MqttFactory();
+            var mqttClient = mqttFactory.CreateMqttClient();
+            var optionBuilder = new MqttClientOptionsBuilder()
+                .WithClientId("jukeCore")
+                .WithTcpServer(arguments.MqttBrokerIp, arguments.MqttPort)
+                .WithCleanSession();
+
+            if (!string.IsNullOrEmpty(arguments.MqttUsername) &&
+                !string.IsNullOrEmpty(arguments.MqttPassword))
+            {
+                //optionBuilder = optionBuilder.WithCredentials("fhem", "M9x#X/bqx")
+                optionBuilder = optionBuilder.WithCredentials(arguments.MqttUsername, arguments.MqttPassword);
+            }
+
+            var options = optionBuilder.Build();
+
+            var mqttPrefix = arguments.MqttPrefix;
+            var volumeTopicHandler = new VolumeTopicHandler(_mediaPlayer, mqttPrefix);
+            var playIdTopicHandler = new PlayIdTopicHandler(processor, mqttPrefix, arguments.JukeCoreMediaPath);
+            var commandTopicHandler = new CommandTopicHandler(_mediaPlayer, _playlist, mqttPrefix);
+            List<ITopicHandler> topicHandlers = new List<ITopicHandler>
+            {
+                volumeTopicHandler,
+                playIdTopicHandler,
+                commandTopicHandler
+            };
+
+            // only data model members are supported in the value / nameof clause ...
+            var topicsToPublish = new Dictionary<string, string>
+            {
+                {$"jukeCore/{arguments.MqttPrefix}/status/playback", nameof(dataModel.PlaybackState)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/mediaDurationMs", nameof(dataModel.MediaDurationMs)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/mediaFilename", nameof(dataModel.MediaFilename)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/mediaPositionMs", nameof(dataModel.MediaPositionMs)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/volumePercent", nameof(dataModel.VolumePercent)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/buttons/volumeDown", nameof(dataModel.VolumeDownButtonState)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/buttons/volumeUp", nameof(dataModel.VolumeUpButtonState)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/buttons/previous", nameof(dataModel.PreviousButtonState)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/buttons/next", nameof(dataModel.NextButtonState)},
+                {$"jukeCore/{arguments.MqttPrefix}/status/buttons/playPause", nameof(dataModel.PlayPauseButtonState)},
+            };
+
+        var mqttService = new MqttService(mqttClient, options, _console, topicHandlers, topicsToPublish, dataModel, 2000, mqttPrefix);
         }
     }
 }

--- a/JukeCore/VolumeDownButton.cs
+++ b/JukeCore/VolumeDownButton.cs
@@ -7,12 +7,14 @@ namespace JukeCore
     {
         private readonly IMediaPlayer _mediaPlayer;
         private readonly IConsole _console;
+        private readonly JukeCoreDataModel _dataModel;
 
-        public VolumeDownButton(GpioController gpioController, IMediaPlayer mediaPlayer, IConsole console) : base(
+        public VolumeDownButton(GpioController gpioController, IMediaPlayer mediaPlayer, IConsole console, JukeCoreDataModel dataModel) : base(
             gpioController, console)
         {
             _mediaPlayer = mediaPlayer;
             _console = console;
+            _dataModel = dataModel;
             Pressed += OnPressed;
         }
 
@@ -20,6 +22,11 @@ namespace JukeCore
         {
             _console.WriteLine("Volume down button was pressed!");
             _mediaPlayer.Volume -= 5;
+        }
+
+        protected override void SetButtonStateInDataModel(EButtonState buttonState)
+        {
+            _dataModel.VolumeDownButtonState = buttonState;
         }
     }
 }

--- a/JukeCore/VolumeTopicHandler.cs
+++ b/JukeCore/VolumeTopicHandler.cs
@@ -1,0 +1,33 @@
+﻿namespace JukeCore
+{
+    /// <summary>
+    /// Topic handler for volume control
+    /// </summary>
+    public class VolumeTopicHandler : ITopicHandler
+    {
+        private readonly IMediaPlayer _mediaPlayer;
+        private readonly string _mqttPrefix;
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        public VolumeTopicHandler(IMediaPlayer mediaPlayer, string mqttPrefix)
+        {
+            _mediaPlayer = mediaPlayer;
+            _mqttPrefix = mqttPrefix;
+        }
+
+        /// <inheritdoc />
+        public string Topic => $"jukeCore/{_mqttPrefix}/volume";
+
+        /// <inheritdoc />
+        public string Usage => $"Topic: {Topic} Payload: 0 - 100";
+
+        /// <inheritdoc />
+        public void HandlePayload(string payload)
+        {
+            int.TryParse(payload, out int volumePercent);
+            _mediaPlayer.Volume = volumePercent;
+        }
+    }
+}

--- a/JukeCore/VolumeUpButton.cs
+++ b/JukeCore/VolumeUpButton.cs
@@ -7,12 +7,14 @@ namespace JukeCore
     {
         private readonly IMediaPlayer _mediaPlayer;
         private readonly IConsole _console;
+        private readonly JukeCoreDataModel _dataModel;
 
-        public VolumeUpButton(GpioController gpioController, IMediaPlayer mediaPlayer, IConsole console) : base(
+        public VolumeUpButton(GpioController gpioController, IMediaPlayer mediaPlayer, IConsole console, JukeCoreDataModel dataModel) : base(
             gpioController, console)
         {
             _mediaPlayer = mediaPlayer;
             _console = console;
+            _dataModel = dataModel;
             Pressed += OnPressed;
         }
 
@@ -20,6 +22,11 @@ namespace JukeCore
         {
             _console.WriteLine("Volume up button was pressed!");
             _mediaPlayer.Volume += 5;
+        }
+
+        protected override void SetButtonStateInDataModel(EButtonState buttonState)
+        {
+            _dataModel.VolumeUpButtonState = buttonState;
         }
     }
 }


### PR DESCRIPTION
This PR is based on the powerargs PR and needs to be merged afterwards.

This adds mqtt support. All supported topics are printed in the console. Mqtt needs to be activated via these optional command line parameters. Not providing the -h parameter results in mqtt being deactivated:


-h mqtt host / ip
-d mqtt port 
-u mqtt username 
-p mqtt password (mandatory whenever -u is given)
-x mqtt prefix (required whenever -h is given)

All messages are published to and subscribed from jukeCore/givenprefix/#

Supported subscriptions (controlling juke core from mqtt side) - foo is the prefix in this example

Registered handler for Topic: jukeCore/foo/volume Payload: 0 - 100
Registered handler for Topic: jukeCore/foo/playId Payload: <rfid id>
Registered handler for Topic: jukeCore/foo/command Payload: <NextTrack|PreviousTrack|PlayPause>

Published data:

Will publish dataModel.PlaybackState to jukeCore/foo/status/playback
Will publish dataModel.MediaDurationMs to jukeCore/foo/status/mediaDurationMs
Will publish dataModel.MediaFilename to jukeCore/foo/status/mediaFilename
Will publish dataModel.MediaPositionMs to jukeCore/foo/status/mediaPositionMs
Will publish dataModel.VolumePercent to jukeCore/foo/status/volumePercent
Will publish dataModel.VolumeDownButtonState to jukeCore/foo/status/buttons/volumeDown
Will publish dataModel.VolumeUpButtonState to jukeCore/foo/status/buttons/volumeUp
Will publish dataModel.PreviousButtonState to jukeCore/foo/status/buttons/previous
Will publish dataModel.NextButtonState to jukeCore/foo/status/buttons/next
Will publish dataModel.PlayPauseButtonState to jukeCore/foo/status/buttons/playPause

top 5 commits